### PR TITLE
chore: disable macos CI

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,4 +7,5 @@ jobs:
   code:
     uses: repobuddy/.github/.github/workflows/pnpm-verify.yml@main
     with:
+      os: '["ubuntu-latest", "windows-latest"]'
       node-version: '[18, 20]'


### PR DESCRIPTION
Due to https://github.com/vercel/turbo/issues/7057