### PR TITLE
fix(setup-github-repo): correct arg parsing and gh merge-commit flag

### DIFF
--- a/skills/setup-github-repo/SKILL.md
+++ b/skills/setup-github-repo/SKILL.md
@@ -63,7 +63,7 @@ Always apply (no extra confirmation needed after Step 1):
 gh repo edit "$REPO" \
   --delete-branch-on-merge \
   --enable-auto-merge \
-  --no-allow-merge-commit \
+  --enable-merge-commit=false \
   --allow-squash-merge \
   --allow-rebase-merge \
   --allow-update-branch

--- a/skills/setup-github-repo/scripts/scaffold-workflows.mts
+++ b/skills/setup-github-repo/scripts/scaffold-workflows.mts
@@ -10,14 +10,25 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { createInterface } from 'node:readline'
+import { parseArgs } from 'node:util'
 
 // --- Args ---
 
-const args = process.argv.slice(2)
-const statePath = args[args.indexOf('--state') + 1] ?? '.github/setup-state.json'
-const workflowsArg = args[args.indexOf('--workflows') + 1]
-const autoYes = args.includes('--yes') || args.includes('-y')
-const verbose = args.includes('--verbose')
+const { values } = parseArgs({
+	options: {
+		state: { type: 'string', default: '.github/setup-state.json' },
+		workflows: { type: 'string' },
+		yes: { type: 'boolean', short: 'y', default: false },
+		verbose: { type: 'boolean', default: false },
+	},
+	allowPositionals: false,
+	strict: true,
+})
+
+const statePath = values.state
+const workflowsArg = values.workflows
+const autoYes = values.yes
+const verbose = values.verbose
 
 function writeResult(result: Record<string, unknown>) {
 	process.stdout.write(`${JSON.stringify(result)}\n`)


### PR DESCRIPTION
## Summary

- **scaffold-workflows.mts**: Use `parseArgs` from `node:util` so flags work when `--workflows` is omitted (fixes misreading `--state` as a workflow name).
- **SKILL.md**: Replace invalid `--no-allow-merge-commit` with `--enable-merge-commit=false` for `gh repo edit`.

Fixes #518

## Test plan

- [x] `node scaffold-workflows.mts --state .github/setup-state.json --yes` creates workflow files (no `--state.yml` skip)
- [ ] `gh repo edit` Step 2 command runs without unknown-flag error on `gh` 2.92+

Made with [Cursor](https://cursor.com)