### PR TITLE
feat(skills): add setup-npm-trusted-publishing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,7 @@ This is a **pnpm monorepo** managed with [Turborepo](https://turbo.build/). It i
 - `merge-dep-prs` — merge Dependabot/Renovate PRs, handles CI failures
 - `setup-github-pages` — deploy a static site to GitHub Pages (base path, Actions workflow, Pages source)
 - `setup-github-repo` — branch protection, Dependabot, CI setup
+- `setup-npm-trusted-publishing` — register npm trusted publishers (OIDC) to retire `NPM_TOKEN`; one package, an org, or every org owned
 
 **Related skill collections** (separate repos, same install flow):
 - [`repobuddy/agent-changesets`](https://github.com/repobuddy/agent-changesets) — changeset authoring and release setup

--- a/skills/setup-npm-trusted-publishing/SKILL.md
+++ b/skills/setup-npm-trusted-publishing/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: setup-npm-trusted-publishing
+description: Use this skill when configuring npm trusted publishing (OIDC) for a package, an org, or every org you own.
+---
+
+# Setup npm Trusted Publishing
+
+Configure npm trusted publishers so GitHub Actions publishes via OIDC and `NPM_TOKEN` can be retired. Apply when a release pipeline authenticates with a long-lived npm token, or when a token has expired and broken publishing.
+
+## When to use
+
+- A release workflow publishes with `NPM_TOKEN` and you want to remove the token
+- Publishing fails with `E401 Unauthorized - GET .../-/whoami` (expired token)
+- Rolling OIDC across many packages at once
+- Repos live under a personal namespace, where there is no org-level secret scope and every repo needs its own token copy
+
+Not for: adding OIDC support to a release workflow file, or configuring GitHub-side permissions. Do those first — this skill only registers the npm-side trust.
+
+## Prerequisites
+
+| Requirement | Check |
+| --- | --- |
+| npm >= 11.15.0 | `npm --version` |
+| Logged in to npm | `npm whoami` |
+| Account-level 2FA | required; granular tokens that bypass 2FA are rejected |
+| `gh` authenticated | `gh auth status` |
+| Workflow already declares `id-token: write` | on the publishing job |
+| Package already exists on the registry | trust cannot be pre-registered |
+
+## Step 1 — Choose scope
+
+Ask the user which applies; do not assume.
+
+| Scope | Flags |
+| --- | --- |
+| One package | `--package <name> --repo <owner/name>` |
+| One repo, all its packages | `--repo <owner/name>` |
+| One organization or user | `--org <login>` |
+| Every org plus the user's own repos | `--all-orgs` |
+
+`--org` and `--all-orgs` cover source repos only; forks belong to someone else to publish.
+
+## Step 2 — Plan
+
+```bash
+node_major=$(node -e "process.stdout.write(String(process.versions.node.split('.')[0]))")
+SKILL_DIR=$(npx skills path setup-npm-trusted-publishing 2>/dev/null || echo "$HOME/.agents/skills/setup-npm-trusted-publishing")
+RUN="npx tsx"; [ "$node_major" -ge 23 ] && RUN=node
+$RUN "$SKILL_DIR/scripts/npm-trust.mts" plan --org <login> --verbose
+```
+
+Writes `.github/npm-trust-plan.json` and prints a JSON ack. **Do not parse stdout for the plan** — read the artifact:
+
+```bash
+jq '[.rows[] | select(.action == "configure")] | length' .github/npm-trust-plan.json
+jq -r '.rows[] | "\(.action)\t\(.package)\t\(.repo)/\(.workflow)"' .github/npm-trust-plan.json
+```
+
+Row actions: `configure`, `already-configured`, `not-published`, `private`.
+
+## Step 3 — Review the plan before applying
+
+Check each against the user's intent:
+
+- **Package count exceeds repo count** — expected. Trust is per package name, so a monorepo publishing four packages needs four rows.
+- **`workflow` names the caller** — npm validates the entry-point workflow (`release.yml`), never the reusable workflow it delegates to. A row naming a reusable workflow will authenticate and then be rejected at publish time.
+- **`not-published` rows** — the package must exist on the registry first. Drop them or publish once with a token.
+- **`private` rows** — repo publishes nothing; confirm that matches expectation rather than a mis-detected workspace layout.
+
+Show the user the `configure` rows and confirm before applying.
+
+## Step 4 — Apply
+
+Applying needs a 2FA code. One success opens a window of roughly five minutes / eighty packages, so a batch runs under a single authentication.
+
+```bash
+$RUN "$SKILL_DIR/scripts/npm-trust.mts" apply --otp=<6-digit code> --verbose
+```
+
+The script stops on the first `EOTP`/`E401`/`E403` rather than repeating an auth failure across the list. On `EOTP`, get a fresh code and re-run — completed rows are skipped.
+
+If npm answers with a browser URL rather than accepting `--otp`, the account uses web-based 2FA. Run one `npm trust github …` directly in an interactive terminal, authenticate in the browser to open the window, then re-run apply.
+
+## Step 5 — Verify
+
+```bash
+npm trust list <package>
+```
+
+Confirm repository, workflow filename, and `publish` permission. Then confirm the next release publishes without `NPM_TOKEN` before deleting any secret.
+
+## Step 6 — Retire the token (separate, deliberate)
+
+Only after a release has published through OIDC:
+
+1. Delete `NPM_TOKEN` from repo secrets (`gh secret delete NPM_TOKEN --repo <owner/name>`).
+2. Optionally set **Require two-factor authentication and disallow tokens** in the package's Publishing access settings.
+
+Step 2 is a one-way narrowing that breaks every remaining token-based publish for that package. Never bundle it with Step 4.
+
+## Anti-patterns
+
+- Passing `--otp <code>` with a space — `npm trust github` takes a positional package name and consumes the value, failing with `Unknown positional argument`. Use `--otp=<code>`.
+- Using the reusable workflow filename in `--file` instead of the caller.
+- Treating trust as per repo — it is per package name, one config per package.
+- Re-running against a package that already has a publisher; that errors rather than updating. Use `npm trust revoke <pkg> --id=<trust-id>` first.
+- Enabling "disallow tokens" in the same pass as registering trust, before any OIDC publish has succeeded.
+- Bulk-applying without fail-fast, spending one 2FA code per package on an auth fault that affects all of them.
+- Assuming registering trust disables token publishing. It is additive; both work until tokens are explicitly disallowed.
+
+## References
+
+- `npx cyber-skills governance show agent-tool-output` — stdout/stderr contract for the bundled script
+- https://docs.npmjs.com/trusted-publishers/ — trusted publisher concepts and web UI equivalent
+- https://docs.npmjs.com/cli/v11/commands/npm-trust/ — `npm trust` subcommands and flags

--- a/skills/setup-npm-trusted-publishing/scripts/npm-trust.mts
+++ b/skills/setup-npm-trusted-publishing/scripts/npm-trust.mts
@@ -1,0 +1,305 @@
+#!/usr/bin/env node
+/**
+ * Plans and applies npm trusted publishing (OIDC) config across one or many repos.
+ *
+ * plan  -- resolves scope to a package list, writes .github/npm-trust-plan.json
+ * apply -- executes the plan, one `npm trust github` call per package
+ *
+ * stdout: JSON ack only. stderr: human-readable detail (--verbose).
+ *
+ * TODO: extract to packages/buddy as `buddy npm trust plan|apply` once the CLI grows a
+ * command surface; the skill keeps WHEN to run it, the CLI keeps HOW.
+ */
+
+import { execFileSync, execSync } from 'node:child_process'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+
+const argv = process.argv.slice(2)
+const mode = argv[0]
+const verbose = argv.includes('--verbose')
+
+function flag(name: string): string | undefined {
+	const eq = argv.find((a) => a.startsWith(`--${name}=`))
+	if (eq) return eq.slice(name.length + 3)
+	const i = argv.indexOf(`--${name}`)
+	return i >= 0 ? argv[i + 1] : undefined
+}
+
+function log(msg: string) {
+	if (verbose) process.stderr.write(`${msg}\n`)
+}
+
+function sh(cmd: string): string {
+	return execSync(cmd, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim()
+}
+
+function shJson<T>(cmd: string): T | null {
+	try {
+		return JSON.parse(sh(cmd)) as T
+	} catch {
+		return null
+	}
+}
+
+function ghFile(repo: string, path: string): string | null {
+	try {
+		const b64 = sh(`gh api repos/${repo}/contents/${path} --jq .content`)
+		return Buffer.from(b64, 'base64').toString('utf8')
+	} catch {
+		return null
+	}
+}
+
+function ghDirs(repo: string, path: string): string[] {
+	const out = shJson<Array<{ name: string; type: string }>>(`gh api repos/${repo}/contents/${path}`)
+	return (out ?? []).filter((e) => e.type === 'dir').map((e) => e.name)
+}
+
+const PLAN_PATH = '.github/npm-trust-plan.json'
+
+type Row = {
+	package: string
+	repo: string
+	workflow: string
+	action: 'configure' | 'already-configured' | 'not-published' | 'private'
+	note?: string
+}
+
+// --- scope resolution -------------------------------------------------------
+
+function resolveRepos(): string[] {
+	const repo = flag('repo')
+	if (repo) return [repo]
+
+	const org = flag('org')
+	if (org) return listRepos(org)
+
+	if (argv.includes('--all-orgs')) {
+		const me = sh('gh api user --jq .login')
+		const orgs = sh('gh api user/orgs --jq ".[].login"').split('\n').filter(Boolean)
+		log(`owner: ${me}; orgs: ${orgs.join(', ') || '(none)'}`)
+		return [me, ...orgs].flatMap((o) => listRepos(o))
+	}
+
+	throw new Error('scope required: --package <name> | --repo <owner/name> | --org <login> | --all-orgs')
+}
+
+function listRepos(owner: string): string[] {
+	// Source repos only. Forks are someone else's to publish.
+	const names = sh(
+		`gh repo list ${owner} --source --no-archived --limit 500 --json nameWithOwner --jq ".[].nameWithOwner"`
+	)
+	return names ? names.split('\n').filter(Boolean) : []
+}
+
+// --- package derivation -----------------------------------------------------
+
+/** npm trust config is per PACKAGE NAME, not per repo, so monorepos yield many rows. */
+function derivePackages(repo: string): Array<{ name: string }> {
+	const rootRaw = ghFile(repo, 'package.json')
+	if (!rootRaw) return []
+
+	let root: any
+	try {
+		root = JSON.parse(rootRaw)
+	} catch {
+		return []
+	}
+
+	if (!root.private && root.name) return [{ name: root.name }]
+
+	// Private root => monorepo. Resolve workspace globs, then fall back to a top-level scan.
+	const globs: string[] = Array.isArray(root.workspaces)
+		? root.workspaces
+		: Array.isArray(root.workspaces?.packages)
+			? root.workspaces.packages
+			: parsePnpmWorkspace(repo)
+
+	const dirs = new Set<string>()
+	for (const g of globs) {
+		const m = /^([^*]+)\/\*$/.exec(g)
+		if (m) for (const d of ghDirs(repo, m[1])) dirs.add(`${m[1]}/${d}`)
+		else if (!g.includes('*')) dirs.add(g)
+	}
+	if (dirs.size === 0) for (const d of ghDirs(repo, '')) dirs.add(d)
+
+	const out: Array<{ name: string }> = []
+	for (const d of dirs) {
+		if (d.startsWith('.')) continue
+		const raw = ghFile(repo, `${d}/package.json`)
+		if (!raw) continue
+		try {
+			const p = JSON.parse(raw)
+			if (p.name && !p.private) out.push({ name: p.name })
+		} catch {
+			/* ignore unparseable */
+		}
+	}
+	return out
+}
+
+function parsePnpmWorkspace(repo: string): string[] {
+	const raw = ghFile(repo, 'pnpm-workspace.yaml')
+	if (!raw) return []
+	const globs: string[] = []
+	let inPackages = false
+	for (const line of raw.split('\n')) {
+		if (/^packages:/.test(line)) {
+			inPackages = true
+			continue
+		}
+		if (inPackages) {
+			const m = /^\s+-\s+['"]?([^'"\s]+)['"]?/.exec(line)
+			if (m) globs.push(m[1])
+			else if (/^\S/.test(line)) inPackages = false
+		}
+	}
+	return globs
+}
+
+/**
+ * npm validates the CALLER workflow, not the reusable one it delegates to.
+ * A workflow qualifies only if it both triggers on push to the default branch AND
+ * actually publishes; scoring then prefers one named `release`.
+ */
+function detectCallerWorkflow(repo: string): { workflow: string; confident: boolean } {
+	const files = shJson<Array<{ name: string }>>(`gh api repos/${repo}/contents/.github/workflows`) ?? []
+	const names = files.map((f) => f.name).filter((n) => /\.ya?ml$/.test(n))
+
+	const scored: Array<{ name: string; score: number }> = []
+	for (const n of names) {
+		const body = ghFile(repo, `.github/workflows/${n}`) ?? ''
+		// Alternation must be grouped, or `main|master` matches anywhere in the file.
+		if (!/push:[\s\S]{0,300}?branches:\s*\[?\s*['"]?(main|master)\b/.test(body)) continue
+		if (!/(changeset\s+publish|npm\s+publish|semantic-release|release-changeset|release-semantic|npm-release|yarn2-library-release)/i.test(body))
+			continue
+		let score = 0
+		if (/^release\.ya?ml$/i.test(n)) score += 2
+		else if (/release|publish/i.test(n)) score += 1
+		scored.push({ name: n, score })
+	}
+	scored.sort((a, b) => b.score - a.score)
+
+	if (scored.length > 0) return { workflow: scored[0].name, confident: scored.length === 1 || scored[0].score > 0 }
+	// Nothing matched: fall back, but say so rather than assert a guess.
+	return { workflow: names.includes('release.yml') ? 'release.yml' : (names[0] ?? 'release.yml'), confident: false }
+}
+
+function isPublished(pkg: string): boolean {
+	try {
+		sh(`npm view ${pkg} version`)
+		return true
+	} catch {
+		return false
+	}
+}
+
+// --- plan -------------------------------------------------------------------
+
+function doPlan() {
+	const single = flag('package')
+	const rows: Row[] = []
+
+	if (single) {
+		const repo = flag('repo')
+		if (!repo) throw new Error('--package requires --repo <owner/name>')
+		const override = flag('file')
+		const det = override ? { workflow: override, confident: true } : detectCallerWorkflow(repo)
+		rows.push({
+			package: single,
+			repo,
+			workflow: det.workflow,
+			action: isPublished(single) ? 'configure' : 'not-published',
+			...(det.confident ? {} : { note: 'workflow guessed - confirm before applying' })
+		})
+	} else {
+		for (const repo of resolveRepos()) {
+			log(`scanning ${repo}`)
+			const pkgs = derivePackages(repo)
+			if (pkgs.length === 0) {
+				rows.push({ package: '-', repo, workflow: '-', action: 'private', note: 'nothing published' })
+				continue
+			}
+			const det = detectCallerWorkflow(repo)
+			for (const p of pkgs) {
+				rows.push({
+					package: p.name,
+					repo,
+					workflow: det.workflow,
+					action: isPublished(p.name) ? 'configure' : 'not-published',
+					...(det.confident ? {} : { note: 'workflow guessed - confirm before applying' })
+				})
+			}
+		}
+	}
+
+	mkdirSync(dirname(PLAN_PATH), { recursive: true })
+	writeFileSync(PLAN_PATH, `${JSON.stringify({ generated: true, rows }, null, 2)}\n`)
+
+	if (verbose) {
+		for (const r of rows) process.stderr.write(`${r.action.padEnd(18)} ${r.package} <- ${r.repo}/${r.workflow}\n`)
+	}
+
+	const counts = rows.reduce<Record<string, number>>((a, r) => ((a[r.action] = (a[r.action] ?? 0) + 1), a), {})
+	process.stdout.write(`${JSON.stringify({ ok: true, plan: PLAN_PATH, total: rows.length, counts })}\n`)
+}
+
+// --- apply ------------------------------------------------------------------
+
+function doApply() {
+	if (!existsSync(PLAN_PATH)) throw new Error(`no plan at ${PLAN_PATH}; run plan first`)
+	const otp = flag('otp')
+	if (!otp) throw new Error('--otp=<code> required; npm enforces 2FA on trust operations')
+
+	const plan = JSON.parse(readFileSync(PLAN_PATH, 'utf8')) as { rows: Row[] }
+	const todo = plan.rows.filter((r) => r.action === 'configure')
+
+	let ok = 0
+	let failed = 0
+	for (const r of todo) {
+		// --otp=VALUE must use the equals form: `npm trust github` takes a positional
+		// package name, so a space-separated value is consumed as that positional.
+		const args = [
+			'trust',
+			'github',
+			r.package,
+			'--file',
+			r.workflow,
+			'--repo',
+			r.repo,
+			'--allow-publish',
+			'-y',
+			`--otp=${otp}`
+		]
+		try {
+			execFileSync('npm', args, { stdio: ['ignore', 'ignore', 'pipe'] })
+			log(`OK      ${r.package}`)
+			ok++
+		} catch (e: any) {
+			const err = String(e.stderr ?? e.message ?? '')
+			process.stderr.write(`FAILED  ${r.package}: ${err.split('\n').find((l) => /npm error/.test(l)) ?? err}\n`)
+			failed++
+			// Auth failures hit every package identically; stop rather than burn the list.
+			if (/EOTP|E401|E403|Unauthorized|Forbidden/.test(err)) {
+				process.stdout.write(`${JSON.stringify({ ok: false, configured: ok, failed, stoppedOn: r.package, reason: 'auth' })}\n`)
+				process.exit(1)
+			}
+		}
+		Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 2000) // rate limit
+	}
+
+	process.stdout.write(`${JSON.stringify({ ok: failed === 0, configured: ok, failed })}\n`)
+}
+
+try {
+	if (mode === 'plan') doPlan()
+	else if (mode === 'apply') doApply()
+	else {
+		process.stderr.write('usage: npm-trust.mts plan|apply [--package|--repo|--org|--all-orgs] [--otp=code] [--verbose]\n')
+		process.exit(2)
+	}
+} catch (e: any) {
+	process.stdout.write(`${JSON.stringify({ ok: false, error: String(e.message ?? e) })}\n`)
+	process.exit(1)
+}

--- a/skills/setup-npm-trusted-publishing/scripts/npm-trust.mts
+++ b/skills/setup-npm-trusted-publishing/scripts/npm-trust.mts
@@ -88,7 +88,7 @@ function resolveRepos(): string[] {
 function listRepos(owner: string): string[] {
 	// Source repos only. Forks are someone else's to publish.
 	const names = sh(
-		`gh repo list ${owner} --source --no-archived --limit 500 --json nameWithOwner --jq ".[].nameWithOwner"`
+		`gh repo list ${owner} --source --no-archived --limit 500 --json nameWithOwner --jq ".[].nameWithOwner"`,
 	)
 	return names ? names.split('\n').filter(Boolean) : []
 }
@@ -172,7 +172,11 @@ function detectCallerWorkflow(repo: string): { workflow: string; confident: bool
 		const body = ghFile(repo, `.github/workflows/${n}`) ?? ''
 		// Alternation must be grouped, or `main|master` matches anywhere in the file.
 		if (!/push:[\s\S]{0,300}?branches:\s*\[?\s*['"]?(main|master)\b/.test(body)) continue
-		if (!/(changeset\s+publish|npm\s+publish|semantic-release|release-changeset|release-semantic|npm-release|yarn2-library-release)/i.test(body))
+		if (
+			!/(changeset\s+publish|npm\s+publish|semantic-release|release-changeset|release-semantic|npm-release|yarn2-library-release)/i.test(
+				body,
+			)
+		)
 			continue
 		let score = 0
 		if (/^release\.ya?ml$/i.test(n)) score += 2
@@ -211,7 +215,7 @@ function doPlan() {
 			repo,
 			workflow: det.workflow,
 			action: isPublished(single) ? 'configure' : 'not-published',
-			...(det.confident ? {} : { note: 'workflow guessed - confirm before applying' })
+			...(det.confident ? {} : { note: 'workflow guessed - confirm before applying' }),
 		})
 	} else {
 		for (const repo of resolveRepos()) {
@@ -228,7 +232,7 @@ function doPlan() {
 					repo,
 					workflow: det.workflow,
 					action: isPublished(p.name) ? 'configure' : 'not-published',
-					...(det.confident ? {} : { note: 'workflow guessed - confirm before applying' })
+					...(det.confident ? {} : { note: 'workflow guessed - confirm before applying' }),
 				})
 			}
 		}
@@ -270,7 +274,7 @@ function doApply() {
 			r.repo,
 			'--allow-publish',
 			'-y',
-			`--otp=${otp}`
+			`--otp=${otp}`,
 		]
 		try {
 			execFileSync('npm', args, { stdio: ['ignore', 'ignore', 'pipe'] })
@@ -282,7 +286,9 @@ function doApply() {
 			failed++
 			// Auth failures hit every package identically; stop rather than burn the list.
 			if (/EOTP|E401|E403|Unauthorized|Forbidden/.test(err)) {
-				process.stdout.write(`${JSON.stringify({ ok: false, configured: ok, failed, stoppedOn: r.package, reason: 'auth' })}\n`)
+				process.stdout.write(
+					`${JSON.stringify({ ok: false, configured: ok, failed, stoppedOn: r.package, reason: 'auth' })}\n`,
+				)
 				process.exit(1)
 			}
 		}
@@ -296,7 +302,9 @@ try {
 	if (mode === 'plan') doPlan()
 	else if (mode === 'apply') doApply()
 	else {
-		process.stderr.write('usage: npm-trust.mts plan|apply [--package|--repo|--org|--all-orgs] [--otp=code] [--verbose]\n')
+		process.stderr.write(
+			'usage: npm-trust.mts plan|apply [--package|--repo|--org|--all-orgs] [--otp=code] [--verbose]\n',
+		)
 		process.exit(2)
 	}
 } catch (e: any) {


### PR DESCRIPTION
Adds a public skill for registering npm trusted publishers (OIDC), so release workflows publish without `NPM_TOKEN`. Scoped to **one package, one repo, one org, or every org the user owns**.

## Where this came from

Migrating `unional/search-packages` off tokens, then sweeping all 106 source repos under `unional/*` for the same fault. That sweep found **3 repos silently not publishing since May** on expired `NPM_TOKEN`s (`E401 ... /-/whoami`) and **2 more** failing on a CI PAT the repo never had. Trusted publishing removes that class of failure rather than re-papering it.

## What the skill encodes

Decisions that determine whether the operation succeeds — each learned by getting it wrong first:

| Decision | Why it matters |
|---|---|
| Trust is per **package name**, not per repo | a monorepo publishing 4 packages needs 4 calls |
| `--file` names the **caller** workflow | npm validates the entry point, not the reusable workflow it delegates to |
| `--otp=` equals form | `npm trust github` takes a positional package name and otherwise consumes the code as that positional |
| `-y` skips confirmation, not 2FA | without a code every call fails `EOTP` |
| Registering trust is **additive** | token publishing keeps working until explicitly disallowed |

Disallowing tokens is a one-way narrowing, so it is a deliberate final step kept out of the bulk path — never bundled with registration.

## Script

`scripts/npm-trust.mts` handles the deterministic half, per skill-design § *Extract deterministic logic*:

- **plan** — resolves scope (source repos only; forks belong to someone else), derives published package names from workspace layout (`workspaces`, `pnpm-workspace.yaml`, or a top-level scan), detects the caller workflow, and writes a reviewable `.github/npm-trust-plan.json`
- **apply** — one `npm trust github` per row, **fail-fast on `EOTP`/`E401`/`E403`** so a single bad code doesn't burn the whole list

Follows the `agent-tool-output` contract: JSON ack on stdout, human detail on stderr behind `--verbose`, state read from the artifact rather than parsed from stdout — matching `setup-github-repo`.

Carries a TODO to fold into `packages/buddy` as `buddy npm trust plan|apply` once that CLI grows a command surface.

## Verification

- `npx cyber-skills audit validate` — no CRITICAL findings (the one repo warning is pre-existing in the installed `add-changeset`)
- description 106 chars, contains "Use this skill when", name matches directory
- plan verified read-only against `unional/standard-log` (4 packages), `unional/search-packages`, and `unional/color-map` — all resolve `release.yml`, matching values derived by hand during the sweep

Testing caught a real bug pre-merge: an ungrouped `main|master` alternation made detection return `codeql-analysis.yml`. Detection now requires a workflow to *both* push to the default branch *and* actually publish, scores `release.yml` highest, and flags low-confidence guesses in the plan for human confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)